### PR TITLE
Add project-wide .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+target
+.idea


### PR DESCRIPTION
This is a starting point to help us avoid checking in files that shouldn't belong in the source code repo.