### PR TITLE
setting default locality wait to 24h

### DIFF
--- a/pipeline/src/main/java/BC_SETTINGS.java
+++ b/pipeline/src/main/java/BC_SETTINGS.java
@@ -65,7 +65,7 @@ public final class BC_SETTINGS
     /* CLUSTER */
     public List< String > transfer_files;
     public String  spark_log_level = "INFO";
-    public String  locality_wait = "";
+    public String  locality_wait = "24h";
     public boolean set_dyn_alloc = false;
     public boolean with_dyn_alloc = false;
     public String  executor_memory = "";


### PR DESCRIPTION
'infinity' is not a valid value for this setting ( I have tried )
You can always overwrite it in the ini.json. It has been a possible key-value pair from the beginning.