### PR TITLE
possiblility to add ballast to the DATABASE-RDD-ENTRY

### DIFF
--- a/pipeline/src/main/java/BC_DATABASE_RDD_ENTRY.java
+++ b/pipeline/src/main/java/BC_DATABASE_RDD_ENTRY.java
@@ -34,6 +34,7 @@ import java.io.FileNotFoundException;
 import java.util.List;
 import java.util.ArrayList;
 import java.util.Iterator;
+import java.util.Random;
 
 import java.net.InetAddress;
 
@@ -68,7 +69,18 @@ public class BC_DATABASE_RDD_ENTRY implements Serializable
         setting = a_setting;
         chunk = a_chunk;
         if ( setting.ballast > 0 )
+        {
             ballast = new byte[ setting.ballast ];
+            try
+            {
+                Random rand = new Random();
+                rand.nextBytes( ballast );
+            }
+            catch( Exception e )
+            {
+                e.printStackTrace();
+            }
+        }
         else
             ballast = null;
     }

--- a/pipeline/src/main/java/BC_DATABASE_RDD_ENTRY.java
+++ b/pipeline/src/main/java/BC_DATABASE_RDD_ENTRY.java
@@ -53,6 +53,7 @@ public class BC_DATABASE_RDD_ENTRY implements Serializable
     private final BC_DATABASE_SETTING setting;
     public final BC_CHUNK_VALUES chunk;
     private static Object mutex = new Object();
+    private final byte[] ballast;
 
 /**
  * create instance BC_DATABASE_RDD_ENTRY
@@ -66,6 +67,10 @@ public class BC_DATABASE_RDD_ENTRY implements Serializable
     {
         setting = a_setting;
         chunk = a_chunk;
+        if ( setting.ballast > 0 )
+            ballast = new byte[ setting.ballast ];
+        else
+            ballast = null;
     }
 
 /**
@@ -266,19 +271,19 @@ public class BC_DATABASE_RDD_ENTRY implements Serializable
 
             // synchronize threads within a jvm
             synchronized(mutex) {
-                
+
                 try {
 
                     f_out = new FileOutputStream( ff );
 
                     // synchronize jvms
                     f_lock = f_out.getChannel().lock();
-                    
+
                     if ( f.exists() ) {
                         long fl = f.length();
                         /* we can now check the size... */
                         if ( obj.size.longValue() == fl ) {
-                            info_lst.add( String.format( 
+                            info_lst.add( String.format(
                                           "%s : %s -> %s (exists size = %d )",
                                           wn, src, dst, fl ) );
                         }

--- a/pipeline/src/main/java/BC_DATABASE_SETTING.java
+++ b/pipeline/src/main/java/BC_DATABASE_SETTING.java
@@ -48,6 +48,7 @@ public class BC_DATABASE_SETTING implements Serializable
     public Boolean direct = false;      /* are we adressing the chunks directly, in case of on-premise */
     public int limit = 0;               /* in case we want to limit the number of db-chunks */
     public List< String > extensions;   /* for nt: nsq, nin, nhr / nr: psq, pin, phr */
+    public int ballast = 0;             /* how much (unused) ballast we want to add to each RDD-entry */
 
 /**
  * create instance of BC_DATABASE_SETTING
@@ -81,6 +82,8 @@ public class BC_DATABASE_SETTING implements Serializable
         S =  S  +  String.format( "\t(%s).extensions ...... %s\n", key, extensions );
         if ( limit > 0 )
             S =  S  +  String.format( "\t(%s).limit ........... %d\n", key, limit );
+        if ( ballast > 0 )
+            S =  S  +  String.format( "\t(%s).ballast ......... %d\n", key, ballast );
         return S;
     }
 }

--- a/pipeline/src/main/java/BC_SETTINGS.java
+++ b/pipeline/src/main/java/BC_SETTINGS.java
@@ -65,7 +65,7 @@ public final class BC_SETTINGS
     /* CLUSTER */
     public List< String > transfer_files;
     public String  spark_log_level = "INFO";
-    public String  locality_wait = "24h";
+    public String  locality_wait = "";
     public boolean set_dyn_alloc = false;
     public boolean with_dyn_alloc = false;
     public String  executor_memory = "";

--- a/pipeline/src/main/java/BC_SETTINGS_READER.java
+++ b/pipeline/src/main/java/BC_SETTINGS_READER.java
@@ -181,6 +181,7 @@ class DATABASES_SETTINGS_READER
     private static final String key_ext = "extensions";
     private static final String key_direct = "direct";
     private static final String key_limit = "limit";
+    private static final String key_ballast = "ballast";
 
 /**
  * extracts all database-settings from the JsonObject
@@ -215,6 +216,8 @@ class DATABASES_SETTINGS_READER
                         key_direct, db_settings.direct );
                     db_settings.limit = BC_JSON_UTILS.get_json_int( obj,
                         key_limit, db_settings.limit );
+                    db_settings.ballast = BC_JSON_UTILS.get_json_int( obj,
+                        key_ballast, db_settings.ballast );
 
                     if ( !db_settings.key.isEmpty() )
                         settings.dbs.put( db_settings.key, db_settings );
@@ -483,7 +486,7 @@ public final class BC_SETTINGS_READER
                 CLUSTER_SETTINGS_READER.from_json( root, res );
                 DEBUG_SETTINGS_READER.from_json( root, res.debug, res.jni_log_level );
             }
-        }           
+        }
         catch( Exception e )
         {
             System.out.println( String.format( "json-parsing: %s", e ) );


### PR DESCRIPTION
This just adds the possibility to increase the 'weight' of the DATABASE-RDD-ENTRY class.
In order to 'play' with it, you have to add the ballast-setting in the ini.json file:

for each database ( nr, nt ):
		{
			"key" : "nr",
			"worker_location" : "/tmp/blast/db",
			"source_location" : "gs://nr_50mb_chunks",
			"extensions" : [ "psq", "pin", "pax" ],
                        "ballast" : 10000
		},

If you are adding too much, you will see this warning:

 WARN org.apache.spark.scheduler.TaskSetManager: Stage 25 contains a task of very large size (985 KB). The maximum recommended task size is 100 KB.

The job will still execute without errors though.
I have not seen an improvement in locality.
This is just one item on our list of things to test for improving locality.
