### PR TITLE
make the number of partitions configurable

### DIFF
--- a/pipeline/src/main/java/BC_MAIN.java
+++ b/pipeline/src/main/java/BC_MAIN.java
@@ -132,7 +132,9 @@ public final class BC_MAIN
              * 16 parallel jobs, 64 partitions each = 1024
              * 16 workers, 64 cores each =            1024
              */
-            JavaRDD< BC_DATABASE_RDD_ENTRY > rdd = jsc.parallelize( entries, 64);
+            JavaRDD< BC_DATABASE_RDD_ENTRY > rdd = settings.num_partitions > 0 ?
+                jsc.parallelize( entries, settings.num_partitions ) :
+                jsc.parallelize( entries );
 
             /* put the RDD in the database-dictionary */
             db_dict.put( key, rdd );

--- a/pipeline/src/main/java/BC_SETTINGS.java
+++ b/pipeline/src/main/java/BC_SETTINGS.java
@@ -74,6 +74,7 @@ public final class BC_SETTINGS
     public boolean scheduler_fair = false;
     public int num_executors = 0;
     public int num_executor_cores = 0;
+    public int num_partitions = 0;
     public int parallel_jobs = 1;
     public String jni_log_level = "INFO";
     public int console_sleep_time = 200;
@@ -223,6 +224,8 @@ public final class BC_SETTINGS
             S = S + String.format( "\tnum-executors ...... %d\n", num_executors );
         if ( num_executor_cores > 0 )
             S = S + String.format( "\tnum-executor-cores . %d\n", num_executor_cores );
+        if ( num_partitions > 0 )
+            S = S + String.format( "\tnum-partitions ..... %d\n", num_partitions );
         S = S + String.format( "\tparallel jobs ...... %d\n", parallel_jobs );
         S = S + String.format( "\tjni log level ...... '%s'\n", jni_log_level );
 

--- a/pipeline/src/main/java/BC_SETTINGS_READER.java
+++ b/pipeline/src/main/java/BC_SETTINGS_READER.java
@@ -339,6 +339,7 @@ class CLUSTER_SETTINGS_READER
     private static final String key_scheduler_fair = "scheduler_fair";
     private static final String key_num_executors = "num_executors";
     private static final String key_num_executor_cores = "num_executor_cores";
+    private static final String key_num_partitions = "num_partitions";
     private static final String key_parallel_jobs = "parallel_jobs";
     private static final String key_jni_log_level = "jni_log_level";
     private static final String  dflt_transfer_file = "libblastjni.so";
@@ -378,6 +379,8 @@ class CLUSTER_SETTINGS_READER
                 key_num_executors, settings.num_executors );
             settings.num_executor_cores = BC_JSON_UTILS.get_json_int( obj,
                 key_num_executor_cores, settings.num_executor_cores );
+            settings.num_partitions = BC_JSON_UTILS.get_json_int( obj,
+                key_num_partitions, settings.num_partitions );
             settings.parallel_jobs = BC_JSON_UTILS.get_json_int( obj,
                 key_parallel_jobs, settings.parallel_jobs);
             settings.jni_log_level = BC_JSON_UTILS.get_json_string( obj,
@@ -483,7 +486,7 @@ public final class BC_SETTINGS_READER
                 CLUSTER_SETTINGS_READER.from_json( root, res );
                 DEBUG_SETTINGS_READER.from_json( root, res.debug, res.jni_log_level );
             }
-        }           
+        }
         catch( Exception e )
         {
             System.out.println( String.format( "json-parsing: %s", e ) );


### PR DESCRIPTION
Avoid hard-coding the number of partitions we are asking for.

in the cluster-sections there is now a new value available: num_partitions
if not used, the default is zero, in this case Spark picks the value