### PR TITLE
provide mapPartitions as alternative to map

### DIFF
--- a/pipeline/src/main/java/BC_SETTINGS.java
+++ b/pipeline/src/main/java/BC_SETTINGS.java
@@ -72,6 +72,7 @@ public final class BC_SETTINGS
     public boolean set_shuffle_reduceLocality = false;
     public boolean shuffle_reduceLocality = false;
     public boolean scheduler_fair = false;
+    public boolean map_partitions = false;
     public int num_executors = 0;
     public int num_executor_cores = 0;
     public int parallel_jobs = 1;
@@ -213,6 +214,8 @@ public final class BC_SETTINGS
             S = S + String.format( "\tlocality.wait ...... '%s'\n", locality_wait );
         if ( set_dyn_alloc )
             S = S + String.format( "\twith_dyn_alloc ..... %s\n", Boolean.toString( with_dyn_alloc ) );
+        S = S + String.format( "\tmap partitions ..... %s\n", Boolean.toString( map_partitions ) );
+
         if ( !executor_memory.isEmpty() )
             S  =  S +  String.format( "\texecutor memory..... %s\n", executor_memory );
         if ( set_shuffle_reduceLocality )

--- a/pipeline/src/main/java/BC_SETTINGS_READER.java
+++ b/pipeline/src/main/java/BC_SETTINGS_READER.java
@@ -333,6 +333,7 @@ class CLUSTER_SETTINGS_READER
     private static final String key_locality_wait = "locality_wait";
     private static final String key_set_dyn_alloc = "set_dyn_alloc";
     private static final String key_with_dyn_alloc = "with_dyn_alloc";
+    private static final String key_map_partitions = "map_partitions";
     private static final String key_executor_memory = "executor_memory";
     private static final String key_set_shuffle_reduceLocality = "set_shuffle_reduceLocality";
     private static final String key_shuffle_reduceLocality = "shuffle_reduceLocality";
@@ -364,6 +365,8 @@ class CLUSTER_SETTINGS_READER
                 key_locality_wait, settings.locality_wait );
             settings.set_dyn_alloc = BC_JSON_UTILS.get_json_bool( obj,
                 key_set_dyn_alloc, settings.set_dyn_alloc );
+            settings.map_partitions = BC_JSON_UTILS.get_json_bool( obj,
+                key_map_partitions, settings.map_partitions );
             settings.with_dyn_alloc = BC_JSON_UTILS.get_json_bool( obj,
                 key_with_dyn_alloc, settings.with_dyn_alloc );
             settings.executor_memory = BC_JSON_UTILS.get_json_string( obj,
@@ -483,7 +486,7 @@ public final class BC_SETTINGS_READER
                 CLUSTER_SETTINGS_READER.from_json( root, res );
                 DEBUG_SETTINGS_READER.from_json( root, res.debug, res.jni_log_level );
             }
-        }           
+        }
         catch( Exception e )
         {
             System.out.println( String.format( "json-parsing: %s", e ) );


### PR DESCRIPTION
this by default does just rdd.map( ... )

but if activated via ini.json:
"cluster" :
    {
	"transfer_files" : [ "libblastjni.so" ],
	"parallel_jobs" : 16,
        "jni_log_level" : "INFO",
        "log_level" : "INFO",
        "map_partitions" : "true"
    }
rdd.mapPartitions( ... ) is performed with preservesPartitioning=true
