### PR TITLE
Set testing defaults

### DIFF
--- a/lib_builder/make_cluster_fixed_config.sh
+++ b/lib_builder/make_cluster_fixed_config.sh
@@ -17,7 +17,7 @@ WORKER=n1-standard-64
 # not as sensitive to this as most Hadoop applications.
 DISK_PER_MASTER=400 # For test data
 DISK_PER_WORKER=400 # For DBs and logs
-NUM_WORKERS=6
+NUM_WORKERS=8
 PREEMPT_WORKERS=0
 
 gcloud beta dataproc \
@@ -31,7 +31,7 @@ gcloud beta dataproc \
         --preemptible-worker-boot-disk-size $DISK_PER_WORKER \
     --scopes cloud-platform \
     --project ncbi-sandbox-blast \
-    --max-age=8h \
+    --max-age=10h \
     --labels "owner=$USER" \
     --region us-east4 \
     --zone   us-east4-c \

--- a/pipeline/nr-ini.json
+++ b/pipeline/nr-ini.json
@@ -1,0 +1,24 @@
+{
+    "databases" :
+    [
+		{
+			"key" : "nr",
+			"worker_location" : "/tmp/blast/db",
+			"source_location" : "gs://nr_50mb_chunks",
+			"extensions" : [ "psq", "pin", "pax" ]
+		}
+	],
+
+    "cluster" :
+    {
+		"transfer_files" : [ "libblastjni.so" ],
+		"parallel_jobs" : 16,
+		"num_partitions" : 128,
+		"locality_wait" : "20s",
+        "num_executors" : 0,
+        "num_executor_cores" : 1,
+        "jni_log_level" : "INFO",
+        "log_level" : "INFO"
+    }
+
+}

--- a/pipeline/nt-ini.json
+++ b/pipeline/nt-ini.json
@@ -2,18 +2,10 @@
     "databases" :
     [
 		{
-			"key" : "nr",
-			"worker_location" : "/tmp/blast/db",
-			"source_location" : "gs://nr_50mb_chunks",
-			"extensions" : [ "psq", "pin", "pax" ],
-			"limit" : 30
-		},
-		{
 			"key" : "nt",
 			"worker_location" : "/tmp/blast/db",
 			"source_location" : "gs://nt_50mb_chunks",
-			"extensions" : [ "nsq", "nin", "nax" ],
-			"limit" : 30
+			"extensions" : [ "nsq", "nin", "nax" ]
 		}
 	],
 
@@ -21,6 +13,10 @@
     {
 		"transfer_files" : [ "libblastjni.so" ],
 		"parallel_jobs" : 16,
+		"num_partitions" : 128,
+		"locality_wait" : "5s",
+        "num_executors" : 0,
+        "num_executor_cores" : 1,
         "jni_log_level" : "INFO",
         "log_level" : "INFO"
     }

--- a/pipeline/run-remotely.sh
+++ b/pipeline/run-remotely.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 # run-remotely.sh: Script to launch the simple spark app at GCP without logging into the master.
 # Assumes cluster started with make_cluster_fixed_config.sh
+# This script is experimental
+
+echo "NOT READY FOR USAGE"
+exit 1
 
 DB=${1:-"nr"}
 CONFIG=$DB-ini.json

--- a/pipeline/run-remotely.sh
+++ b/pipeline/run-remotely.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# run-remotely.sh: Script to launch the simple spark app at GCP without logging into the master.
+# Assumes cluster started with make_cluster_fixed_config.sh
+
+DB=${1:-"nr"}
+CONFIG=$DB-ini.json
+CLUSTER_ID=blast-dataproc-${USER}
+MAIN_CLASS=gov.nih.nlm.ncbi.blastjni.BC_MAIN
+JAR=$(find target -type f -name "*-with-dependencies.jar")
+LOG_CONF="--driver-java-options=-Dlog4j.configuration=file:log4j.properties"
+GCP_REGION=us-east4
+
+if [[ $DB != "nr" && $DB != "nt" ]] ; then
+    echo "Usage: $0 [nr|nt]"
+    exit 1
+fi
+
+[ -f libblastjni.so ] || gsutil cp gs://blast-lib/libblastjni.so .
+
+if [ ! -z "$CLUSTER_ID" ] ; then
+    set -x
+    gcloud dataproc jobs submit spark --jars $JAR \
+        --class ${MAIN_CLASS} \
+        --cluster ${CLUSTER_ID} \
+        --region ${GCP_REGION} \
+        --driver-log-levels=root=INFO \
+        --files=libblastjni.so,$CONFIG,${DB}-searches.txt -- $CONFIG ${DB}-searches.txt
+fi


### PR DESCRIPTION
Summary of changes:
* Replace `ini.json` by `nr-ini.json` and `nt-ini.json` (full BLASTDB searched)
* Configure `lib_builder/make_cluster_fixed_config.sh` to start  cluster with 8 nodes (64 cores each)
* Configure agreed upon default values for 
  * spark.locality.wait
  * number of partitions
  * application paralellism
  * number of executors